### PR TITLE
Fix/title contains artist mismatch

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/bot.py
+++ b/bot.py
@@ -159,9 +159,11 @@ def send_alert(conn, cursor, reddit, submission, artist, username):
     logging.info("Sent message to " + username + " for " + artist + "\n" + submission.title)
 
 def titleContainsArtist(artist, title):
-    cases = [artist + " ", artist + ";", artist + ":", artist + ";", artist + ","]
-    for case in cases:
-        if title.find(case) > 0:
+    title = re.split("[^{a-z}]+", title)
+    artist = re.split("\s", artist)
+    length = len(artist)
+    for i in range(len(title) - length + 1):
+        if title[i:i + length] == artist:
             return True
     return False
 


### PR DESCRIPTION
Use the Python re library to split `title` into a list of words regardless of the number of spaces or symbol between consecutive words, and split the `artist` into a list of words. Then match `artist` inside `title` to return a boolean indicating contained or not.

```
>>> re.split("[^{a-z}]+", "the beatles - abbey road")
['the', 'beatles', 'abbey', 'road']
>>> re.split("[^{a-z}]+", "the beatles:abbey road")
['the', 'beatles', 'abbey', 'road']
>>> re.split("[^{a-z}]+", "   the    beatles   abbey road")
['', 'the', 'beatles', 'abbey', 'road']
```
